### PR TITLE
Allow running emperor as root

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -152,17 +152,6 @@
     dest: "{{ uwsgi_conf_path }}"
     force: "{{ uwsgi_conf_force }}"
   when: uwsgi_conf_template != ''
-
-- name: configure whether uwsgi emperor runs in tyrant mode
-  lineinfile:
-    dest: "{{ uwsgi_conf_path }}"
-    regexp: '^#*?\s*?{{ item.name }}\s*?='
-    line: "{{ item.name }} = {{ item.value }}"
-  with_items:
-    - name: emperor-tyrant
-      value: "{{ uwsgi_emperor_tyrant | bool }}"
-    - name: cap
-      value: "setgid,setuid"
   notify:
     - restart uwsgi
 

--- a/templates/emperor.ini.j2
+++ b/templates/emperor.ini.j2
@@ -25,3 +25,8 @@ gid = {{ uwsgi_user_group.group | default('www-data') }}
 
 # vassals directory
 emperor = {{ uwsgi_vassal_path }}
+
+emperor-tyrant = {{ uwsgi_emperor_tyrant | bool }}
+{% if uwsgi_user_group.name != 'root' and uwsgi_emperor_tyrant | bool %}
+cap = setgid,setuid
+{% endif %}


### PR DESCRIPTION
Hi,
In some vassals setups, it might be required to run emperor as root. If that happens, uid and gid are better left off, but also we need to remove the capabilities. It would be nice in that situation to guarantee that vassals do have a uid/gid set.